### PR TITLE
commit modified version bugfix/#7

### DIFF
--- a/src/common/DoRequest.ts
+++ b/src/common/DoRequest.ts
@@ -9,6 +9,8 @@ import AppError from './AppError';
 import Config from './Config';
 import request = require('request');
 const Message = Config.ReadConfig('./config/message.json');
+const dns = require('dns');
+dns.setDefaultResultOrder('ipv4first');
 
 /**
  * GETリクエストを実行する


### PR DESCRIPTION
# pullrequestタイトル
node18からipv6が優先することに伴いlocalhostの通信に失敗する。

# 概要
## 環境（UT実行バージョン）
- postgres: 15.6
```
$ psql --version
psql (PostgreSQL) 15.6
```
- node: v18.16.0
```
$ fnm use 18
Using Node v18.16.0
```

## 対処内容
- nodejsの通信をipv6優先→ipv4優先に修正した。
- src/common/DoRequest.ts内で以下を追記し、ipv4を優先して利用する設定を入れた。
```
const dns = require('dns');
dns.setDefaultResultOrder('ipv4first');
```

# コマンド実行結果
## npm install実行結果
```
$ npm install
npm WARN deprecated @types/helmet@4.0.0: This is a stub types definition. helmet provides its own type definitions, so you do not need
this installed.
npm WARN deprecated @babel/plugin-proposal-export-namespace-from@7.18.9: This proposal has been merged to the ECMAScript standard and t
hus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances,
 which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

added 830 packages, and audited 831 packages in 2m

156 packages are looking for funding
  run `npm fund` for details

3 moderate severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

```

## ビルド実行結果
```
$ npm run build

> local-ctoken-service@1.0.0 build
> npm-run-all -s lint build:ts


> local-ctoken-service@1.0.0 lint
> eslint ./src/index.ts src/**/*.ts


> local-ctoken-service@1.0.0 build:ts
> node ./node_modules/typescript/bin/tsc

```

## UT実行結果
```
$ npm run test:unit

> local-ctoken-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

 PASS  src/tests/01-01.LocalCToken.spec.ts (44.288 s)
 PASS  src/tests/02-01.CTokenLedger.spec.ts (5.11 s)
 PASS  src/tests/01-02.LocalCToken.insertError.spec.ts
---------------------------------|---------|----------|---------|---------|-------------------
File                             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------------------------|---------|----------|---------|---------|-------------------
All files                        |   99.41 |    98.95 |    98.7 |   99.39 |
 repositories                    |     100 |      100 |     100 |     100 |
  EntityOperation.ts             |     100 |      100 |     100 |     100 |
 resources                       |     100 |      100 |     100 |     100 |
  LedgerController.ts            |     100 |      100 |     100 |     100 |
  LocalCTokenController.ts       |     100 |      100 |     100 |     100 |
 resources/dto                   |     100 |      100 |     100 |     100 |
  PostLedgerReqDto.ts            |     100 |      100 |     100 |     100 |
  PostLocalCTokenReqDto.ts       |     100 |      100 |     100 |     100 |
 resources/validator             |     100 |      100 |     100 |     100 |
  LedgerRequestValidator.ts      |     100 |      100 |     100 |     100 |
  LocalCTokenRequestValidator.ts |     100 |      100 |     100 |     100 |
 services                        |   98.99 |     98.8 |      96 |   98.94 |
  CTokenLedgerService.ts         |     100 |      100 |     100 |     100 |
  LedgerService.ts               |     100 |      100 |     100 |     100 |
  LocalCTokenService.ts          |   97.76 |    97.36 |   91.66 |    97.6 | 64-68
  OperatorService.ts             |     100 |      100 |     100 |     100 |
---------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 3 passed, 3 total
Tests:       200 passed, 200 total
Snapshots:   0 total
Time:        53.916 s
Ran all test suites.

```